### PR TITLE
Quick Fix. Fixed Error Where Charger Would Crush Server on Use. Fixed…

### DIFF
--- a/Content.Server/_Pirate/Power/EntitySystems/IPCChargerSystem.cs
+++ b/Content.Server/_Pirate/Power/EntitySystems/IPCChargerSystem.cs
@@ -2,6 +2,7 @@ using Content.Server._Pirate.Power.Components;
 using Content.Server.Construction.Completions;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
+using Content.Shared._Pirate.Power;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Power;
@@ -25,12 +26,14 @@ namespace Content.Server._Pirate.Power.EntitySystems
                 return;
             if (!TryComp(args.User, out ItemSlotsComponent? itemSlot_component)) // checks if player that`ve used charger can hold items(ie. IPC)
                 return;
+            if (!itemSlot_component.Slots["cell_slot"].HasItem)
+                return;
             if (!TryComp(itemSlot_component.Slots["cell_slot"].Item, out BatteryComponent? batteryComponent)) // checks if the player actually have cell inserted
                 return;
             var appearance = EntityManager.GetComponentOrNull<AppearanceComponent>(uid);
             var soundSpec = new SoundPathSpecifier("/Audio/Effects/PowerSink/charge_fire.ogg");
-            _appearence.SetData(uid, PowerChargeVisuals.Active, PowerChargeStatus.Off, appearance); //TODO: Fix visuals changing
-            _battery.SetCharge(args.User, batteryComponent.CurrentCharge + component.ChargeAmount, batteryComponent);
+            _appearence.SetData(uid, IPCChargerVisuals.Active, false, appearance);
+            _battery.SetCharge(itemSlot_component.Slots["cell_slot"].Item!.Value, batteryComponent.CurrentCharge + component.ChargeAmount, batteryComponent);
             _sound.PlayPvs(soundSpec, uid);
             component.Useable = false;
         }

--- a/Content.Shared/_Pirate/Power/IPCChargerVisuals.cs
+++ b/Content.Shared/_Pirate/Power/IPCChargerVisuals.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Pirate.Power;
+
+[Serializable, NetSerializable]
+public enum IPCChargerVisuals
+{
+    Active
+}
+
+[Serializable, NetSerializable]
+public enum IPCChargerLayers
+{
+    Base,
+    Unshaded
+}

--- a/Resources/Prototypes/_Pirate/Entities/Objects/Power/ipccharger.yml
+++ b/Resources/Prototypes/_Pirate/Entities/Objects/Power/ipccharger.yml
@@ -16,8 +16,14 @@
   components:
     - type: Sprite
       layers:
-        - map: ["enum.PowerCellVisualLayers.Base"]
+        - map: ["enum.IPCChargerLayers.Base"]
           state: disposalcharger
-        - map: ["enum.PowerCellVisualLayers.Unshaded"]
+        - map: ["enum.IPCChargerLayers.Unshaded"]
           state: active
           shader: unshaded
+    - type: GenericVisualizer
+      visuals:
+        enum.IPCChargerVisuals.Active:
+          enum.IPCChargerLayers.Unshaded:
+            True: { visible: true }
+            False: { visible: false }


### PR DESCRIPTION
# Description

This PR addresses two critical issues with the IPC charger:

1. **Server Crash Bug**: The charger was attempting to modify the charge of the IPS device itself rather than the battery inside the IPS. This was causing the server to crash whenever the charger was used.

2. **Visual Feedback Issue**: The charger's sprite wasn't changing when used, providing no visual feedback to users that the charging action had occurred.

These fixes improve stability by preventing server crashes and enhance user experience by providing proper visual feedback when using the charger.

---

# TODO

- [x] Fix server crash when using IPC charger
- [x] Implement proper sprite change for charger when used
- [x] Create new visual enumerations for better code organization
- [x] Update YAML prototype to use new visual layers

---

<details><summary><h1>Media</h1></summary>
<p>

<!-- You can add before/after screenshots here if available -->

</p>
</details>

---

# Changelog

:cl:
- fix: Виправлено помилку коли зарядка для ІПШ крашила сервер при використанні
- fix: Виправлено зміну спрайту для зарядки ІПШ