### PR TITLE
Remove Do Not Resuscitate Trait From IPC

### DIFF
--- a/Resources/Prototypes/_Pirate/Traits/physical.yml
+++ b/Resources/Prototypes/_Pirate/Traits/physical.yml
@@ -99,6 +99,11 @@
   id: DoNotResuscitate
   category: Physical
   points: 10
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
   functions:
     - !type:TraitAddComponent
       components:


### PR DESCRIPTION

# Description

ІПШ більше не зможуть брати трейт який дає 10 поінтів і не працює на них.

---

# TODO


- [x] ІПШ тепер не круті

---

<details><summary><h1>Media</h1></summary>
</details>

---

# Changelog

:cl:
- tweak: ІПШ більше не можуть брати "Не реанімувати".
